### PR TITLE
Docs: Add compilation instructions for macOS via Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,18 @@ Linux:
 
 Mac OS X:
 
+If you installed SFML manually (Frameworks):
+    
     clang++ Transparent.cpp Transparent.mm -framework sfml-graphics -framework sfml-window -framework sfml-system -framework Cocoa
+
+If you installed SFML via Homebrew:
+    
+    clang++ Transparent.cpp Transparent.mm \
+      -I$(brew --prefix sfml@2)/include \
+      -L$(brew --prefix sfml@2)/lib \
+      -lsfml-graphics -lsfml-window -lsfml-system \
+      -framework Cocoa \
+      -std=c++17
 
 
 Windows:


### PR DESCRIPTION
The current macOS compilation instructions assume a Framework installation. I attempted to compile on an M4 Mac using SFML installed via Homebrew, and the existing command fails. I have added an alternative command that points to the correct Homebrew paths.